### PR TITLE
Fix .my_name resolution and add source(self) annotation for beliefs

### DIFF
--- a/agentspeak/runtime.py
+++ b/agentspeak/runtime.py
@@ -622,6 +622,13 @@ class Agent:
         if term.functor is None:
             raise AslError("expected belief literal")
 
+        # Add source(self) annotation if not already present
+        has_source = any(ann.functor == "source" for ann in term.annots)
+        if not has_source:
+            term = term.with_annotation(
+                agentspeak.Literal("source", (agentspeak.Literal("self"), ))
+            )
+
         self.beliefs[(term.functor, len(term.args))].add(term)
 
     def test_belief(self, term, intention):

--- a/agentspeak/stdlib.py
+++ b/agentspeak/stdlib.py
@@ -187,7 +187,8 @@ def _fail(agent, term, intention):
 @actions.add(".my_name", 1)
 @agentspeak.optimizer.function_like
 def _my_name(agent, term, intention):
-    if agentspeak.unify(term.args[0], Literal(agent.name), intention.scope, intention.stack):
+    # MRP: sustituido Literal(agent.name) por str(agent.name).
+    if agentspeak.unify(term.args[0], str(agent.name), intention.scope, intention.stack):
         yield
 
 

--- a/examples/counting/counting.asl
+++ b/examples/counting/counting.asl
@@ -13,6 +13,6 @@ max_count(5).
     -+actual_count(NewCount);
     !count.
 
-+!count : actual_count(X) & max_count(Y) & X >= Y. /*
++!count : actual_count(X) & max_count(Y) & X >= Y <-
     .my_name(Name);
-    .print(Name, " terminated count"). */
+    .print(Name, " terminated count").


### PR DESCRIPTION
## Summary

This PR fixes `.my_name` resolution in `agentspeak/stdlib.py`, adds `source(self)` annotations for beliefs created without an explicit source in `agentspeak/runtime.py`, and enables the counting example for runtime validation.

## Changes

- Update `.my_name` unification to use `str(agent.name)` instead of `Literal(agent.name)`.
- Add `source(self)` automatically when a belief is inserted without an existing `source(...)` annotation.
- Enable `.my_name` usage in `examples/counting/counting.asl` so the example prints the agent name at the end of counting.

## Why

These changes improve consistency in two areas:

- `.my_name` should unify with a plain string value.
- beliefs inserted locally without a source should carry `source(self)` so their origin is explicit and consistent with message-based beliefs.

## Validation

Validated locally by running:

- `pytest -q tests/test_stdlib.py tests/test_terms.py tests/test_parser.py`
- `python -m agentspeak examples/counting/counting.asl`

The test suite passed, and the counting example printed the resolved agent name correctly.

## Scope

This PR is limited to `python-agentspeak` changes related to:

- `.my_name` resolution
- automatic `source(self)` annotation for beliefs
- example-level validation in `examples/counting/counting.asl`